### PR TITLE
fix(tachimanga): resolve library/history sync issues and map preferences

### DIFF
--- a/packages/mangabackupconverter_cli/lib/src/formats/tachi/tachi_backup_preference.dart
+++ b/packages/mangabackupconverter_cli/lib/src/formats/tachi/tachi_backup_preference.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:dart_mappable/dart_mappable.dart';
 import 'package:mangabackupconverter_cli/src/proto/schema_mihon.proto/proto/schema_mihon.pb.dart' as mihon;
 import 'package:mangabackupconverter_cli/src/proto/schema_sy.proto/proto/schema_sy.pb.dart' as sy;
@@ -29,7 +30,7 @@ class TachiBackupPreference with TachiBackupPreferenceMappable {
   static const TachiBackupPreference Function(String json) fromJson = TachiBackupPreferenceMapper.fromJson;
 }
 
-@MappableClass()
+@MappableClass(includeCustomMappers: [TachiBackupPreferenceValueCustomMapper()])
 class TachiBackupPreferenceValue with TachiBackupPreferenceValueMappable {
   final String type;
   final List<int> truevalue;
@@ -47,4 +48,29 @@ class TachiBackupPreferenceValue with TachiBackupPreferenceValueMappable {
   static const TachiBackupPreferenceValue Function(Map<String, dynamic> map) fromMap =
       TachiBackupPreferenceValueMapper.fromMap;
   static const TachiBackupPreferenceValue Function(String json) fromJson = TachiBackupPreferenceValueMapper.fromJson;
+}
+
+class TachiBackupPreferenceValueCustomMapper extends SimpleMapper<TachiBackupPreferenceValue> {
+  const TachiBackupPreferenceValueCustomMapper();
+
+  @override
+  TachiBackupPreferenceValue decode(dynamic value) {
+    final Map<String, dynamic> map = value as Map<String, dynamic>;
+    final String type = map['type'] as String;
+    final dynamic truevalueDynamic = map['truevalue'];
+    List<int> truevalue;
+    if (truevalueDynamic is String) {
+      truevalue = base64Decode(truevalueDynamic);
+    } else if (truevalueDynamic is List) {
+      truevalue = truevalueDynamic.cast<int>();
+    } else {
+      truevalue = <int>[];
+    }
+    return TachiBackupPreferenceValue(type: type, truevalue: truevalue);
+  }
+
+  @override
+  dynamic encode(TachiBackupPreferenceValue self) {
+    return <String, dynamic>{'type': self.type, 'truevalue': base64Encode(self.truevalue)};
+  }
 }

--- a/packages/mangabackupconverter_cli/lib/src/formats/tachimanga/tachimanga_backup_db_models.dart
+++ b/packages/mangabackupconverter_cli/lib/src/formats/tachimanga/tachimanga_backup_db_models.dart
@@ -282,11 +282,11 @@ class TachimangaBackupManga
       thumbnailUrl: thumbnailUrl ?? '',
       source: source,
       updateStrategy: TachiUpdateStrategyMapper.fromValue(int.tryParse(updateStrategy) ?? updateStrategy),
-      dateAdded: DateTime.now().millisecondsSinceEpoch,
+      dateAdded: inLibraryAt > 0 ? inLibraryAt : DateTime.now().millisecondsSinceEpoch,
       viewer: 1,
       viewerFlags: 1,
       chapterFlags: 1,
-      favorite: false,
+      favorite: inLibrary,
       chapters: db.chapterTable
           .where((TachimangaBackupChapter c) => c.manga == id)
           .map((TachimangaBackupChapter c) => c.toType(db))

--- a/packages/mangabackupconverter_cli/lib/src/proto/schema_sy.proto/proto/schema_sy.pb.dart
+++ b/packages/mangabackupconverter_cli/lib/src/proto/schema_sy.proto/proto/schema_sy.pb.dart
@@ -195,6 +195,9 @@ class BackupCategory extends $pb.GeneratedMessage {
     $fixnum.Int64? order,
     $fixnum.Int64? id,
     $fixnum.Int64? flags,
+    $fixnum.Int64? version,
+    $fixnum.Int64? uid,
+    $fixnum.Int64? lastModifiedAt,
   }) {
     final $result = create();
     if (name != null) {
@@ -209,6 +212,15 @@ class BackupCategory extends $pb.GeneratedMessage {
     if (flags != null) {
       $result.flags = flags;
     }
+    if (version != null) {
+      $result.version = version;
+    }
+    if (uid != null) {
+      $result.uid = uid;
+    }
+    if (lastModifiedAt != null) {
+      $result.lastModifiedAt = lastModifiedAt;
+    }
     return $result;
   }
   BackupCategory._() : super();
@@ -222,7 +234,10 @@ class BackupCategory extends $pb.GeneratedMessage {
         ..aQS(1, _omitFieldNames ? '' : 'name')
         ..aInt64(2, _omitFieldNames ? '' : 'order')
         ..aInt64(3, _omitFieldNames ? '' : 'id')
-        ..aInt64(100, _omitFieldNames ? '' : 'flags');
+        ..aInt64(100, _omitFieldNames ? '' : 'flags')
+        ..aInt64(601, _omitFieldNames ? '' : 'version')
+        ..aInt64(602, _omitFieldNames ? '' : 'uid')
+        ..aInt64(603, _omitFieldNames ? '' : 'lastModifiedAt', protoName: 'lastModifiedAt');
 
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -291,6 +306,42 @@ class BackupCategory extends $pb.GeneratedMessage {
   $core.bool hasFlags() => $_has(3);
   @$pb.TagNumber(100)
   void clearFlags() => clearField(100);
+
+  @$pb.TagNumber(601)
+  $fixnum.Int64 get version => $_getI64(4);
+  @$pb.TagNumber(601)
+  set version($fixnum.Int64 v) {
+    $_setInt64(4, v);
+  }
+
+  @$pb.TagNumber(601)
+  $core.bool hasVersion() => $_has(4);
+  @$pb.TagNumber(601)
+  void clearVersion() => clearField(601);
+
+  @$pb.TagNumber(602)
+  $fixnum.Int64 get uid => $_getI64(5);
+  @$pb.TagNumber(602)
+  set uid($fixnum.Int64 v) {
+    $_setInt64(5, v);
+  }
+
+  @$pb.TagNumber(602)
+  $core.bool hasUid() => $_has(5);
+  @$pb.TagNumber(602)
+  void clearUid() => clearField(602);
+
+  @$pb.TagNumber(603)
+  $fixnum.Int64 get lastModifiedAt => $_getI64(6);
+  @$pb.TagNumber(603)
+  set lastModifiedAt($fixnum.Int64 v) {
+    $_setInt64(6, v);
+  }
+
+  @$pb.TagNumber(603)
+  $core.bool hasLastModifiedAt() => $_has(6);
+  @$pb.TagNumber(603)
+  void clearLastModifiedAt() => clearField(603);
 }
 
 /// BackupChapter.kt

--- a/packages/mangabackupconverter_cli/lib/src/proto/schema_sy.proto/proto/schema_sy.pbjson.dart
+++ b/packages/mangabackupconverter_cli/lib/src/proto/schema_sy.proto/proto/schema_sy.pbjson.dart
@@ -82,13 +82,18 @@ const BackupCategory$json = {
     {'1': 'order', '3': 2, '4': 1, '5': 3, '10': 'order'},
     {'1': 'id', '3': 3, '4': 1, '5': 3, '10': 'id'},
     {'1': 'flags', '3': 100, '4': 1, '5': 3, '10': 'flags'},
+    {'1': 'version', '3': 601, '4': 1, '5': 3, '10': 'version'},
+    {'1': 'uid', '3': 602, '4': 1, '5': 3, '10': 'uid'},
+    {'1': 'lastModifiedAt', '3': 603, '4': 1, '5': 3, '10': 'lastModifiedAt'},
   ],
 };
 
 /// Descriptor for `BackupCategory`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List backupCategoryDescriptor =
     $convert.base64Decode('Cg5CYWNrdXBDYXRlZ29yeRISCgRuYW1lGAEgAigJUgRuYW1lEhQKBW9yZGVyGAIgASgDUgVvcm'
-        'RlchIOCgJpZBgDIAEoA1ICaWQSFAoFZmxhZ3MYZCABKANSBWZsYWdz');
+        'RlchIOCgJpZBgDIAEoA1ICaWQSFAoFZmxhZ3MYZCABKANSBWZsYWdzEhkKB3ZlcnNpb24Y2QQg'
+        'ASgDUgd2ZXJzaW9uEhEKA3VpZBjaBCABKANSA3VpZBInCg5sYXN0TW9kaWZpZWRBdBjbBCABKA'
+        'NSDmxhc3RNb2RpZmllZEF0');
 
 @$core.Deprecated('Use backupChapterDescriptor instead')
 const BackupChapter$json = {

--- a/proto/schema_sy.proto
+++ b/proto/schema_sy.proto
@@ -27,6 +27,9 @@ message BackupCategory {
   optional int64 order = 2;
   optional int64 id = 3;
   optional int64 flags = 100;
+  optional int64 version = 601;
+  optional int64 uid = 602;
+  optional int64 lastModifiedAt = 603;
 }
 
 // BackupChapter.kt


### PR DESCRIPTION
This PR containing the fixes for the Tachimanga backup conversion. 

### What this PR does:
This PR resolves critical data loss issues when migrating from Tachimanga to Mihon by fixing the mapping logic for library status, reading history, and app/source preferences.

### Specific Changes:
1. **Library Status**: Maps `favorite` using `inLibrary` instead of hardcoding it to `false`.
2. **History & Tracking**: Corrects the `mediaId` mapping to ensure history and tracking synchronize properly.
3. **App & Source Preferences**: Parses the preference table and accurately converts app settings, source credentials, and source preferences.
4. **Protobuf Deserialization Fix**: Adds `TachiBackupPreferenceValueCustomMapper` to serialize bytes (`truevalue`) as Base64 strings, preventing Protobuf JSON decoding errors.
5. **Updated Schemas**: Includes the necessary `.proto` updates to support the above mappings.
